### PR TITLE
Fix SageMaker capitalization in About page

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -71,7 +71,7 @@
           <div class="expertise-icon">📦</div>
           <div class="expertise-text">
             <h4>Cloud-Native Deployment</h4>
-            <p>Use of Terraform, GitHub Actions, Sagemaker Unified Studio, EKS or Lambda for scalable operations</p>
+            <p>Use of Terraform, GitHub Actions, SageMaker Unified Studio, EKS or Lambda for scalable operations</p>
           </div>
         </li>
       </ul>


### PR DESCRIPTION
## Summary
- fix the spelling of **SageMaker** on the about page

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_683f4fc797b08328b4e34e592496ba2f