### PR TITLE
Add deployment versioning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,10 @@ jobs:
           
       - name: Install dependencies
         run: npm ci
-        
+
+      - name: Determine deploy version
+        run: echo "PUBLIC_DEPLOY_VERSION=v$(git rev-list --count HEAD)" >> $GITHUB_ENV
+
       - name: Build
         run: npm run build
         

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ Post content in Markdown...
    - Uploads to S3
    - Invalidates CloudFront cache
 
+### Versioning
+
+Each deployment is assigned an incremental version number (`v1`, `v2`, ...)
+based on the commit count of the `main` branch. The value is exposed during the
+build as the `PUBLIC_DEPLOY_VERSION` environment variable and shown in the page
+footer for quick verification.
+
 ## Development Guidelines
 
 - Follow Astro's best practices

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,6 @@
 ---
 const currentYear = new Date().getFullYear();
+const version = import.meta.env.PUBLIC_DEPLOY_VERSION ?? 'v0';
 ---
 
 <footer class="footer">
@@ -15,6 +16,7 @@ const currentYear = new Date().getFullYear();
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
       </a>
     </div>
+    <div class="version">Version {version}</div>
   </div>
 </footer>
 
@@ -52,6 +54,12 @@ const currentYear = new Date().getFullYear();
 
   .icon {
     vertical-align: middle;
+  }
+
+  .version {
+    margin-top: var(--space-2);
+    color: var(--color-text-secondary);
+    font-size: 0.75rem;
   }
 
   @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- show deployment version in the footer
- inject PUBLIC_DEPLOY_VERSION during GitHub workflow
- document how deployments are versioned

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f521f72908328a553c9364f8f7931